### PR TITLE
Fix extlinux so that it runs on XenServer

### DIFF
--- a/overlayfs/boot/extlinux/extlinux.conf
+++ b/overlayfs/boot/extlinux/extlinux.conf
@@ -3,7 +3,6 @@ UI menu.c32
 
 LABEL Macchinina
 	MENU LABEL Macchinina
-	LINUX /bzImage
-	INITRD /initrd.igz
-	APPEND ro consoleblank=0
+	KERNEL /bzImage
+	APPEND ro consoleblank=0 initrd=/initrd.igz
 


### PR DESCRIPTION
Fixes #2 

XenServer expects the `extlinux.conf` bootloader file to be in a certain way in order for it to boot.
Verified on `KVM` and `XenServer` works on both
